### PR TITLE
feat: Support optional fields

### DIFF
--- a/django2pydantic/getter.py
+++ b/django2pydantic/getter.py
@@ -58,6 +58,10 @@ class DjangoGetter(DjangoGetterMixin):
             if k.startswith(f"{key}__"):
                 values[k[len(key) + 2 :]] = v
 
+        # If values is empty, bubble up AttributeError as there's no value for the key
+        if not values:
+            raise AttributeError(key)
+
         return values
 
     def __init__(self, obj: Any, schema_cls: Any, context: Any = None) -> None:

--- a/django2pydantic/mixin.py
+++ b/django2pydantic/mixin.py
@@ -18,7 +18,7 @@ class BaseMixins(BaseModel):
         "from_attributes": True,
         "arbitrary_types_allowed": True,
         "use_enum_values": True,
-        "validate_default": True,
+        "validate_default": False,
     }
 
     @model_validator(mode="wrap")


### PR DESCRIPTION
- Optional fields will get a default value `None`, they shouldn't be validated
- DjangoGetter may try to get missing field value from payload, `AttributeError` should be raised in this case

## Summary by Sourcery

Add support for optional fields with default values and modify validation behavior to exclude these fields. Update `DjangoGetter` to raise an `AttributeError` when a field value is missing from the payload.

New Features:
- Introduce support for optional fields with default value `None`, which are not subject to validation.

Bug Fixes:
- Ensure `DjangoGetter` raises an `AttributeError` when attempting to access a missing field value from the payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced error handling in the data retrieval process, providing clearer feedback when no values are found for a requested key.
  
- **Bug Fixes**
	- Adjusted validation behavior for model defaults, ensuring that default values are no longer validated.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->