### PR TITLE
fix: Include django-stubs-ext as a non-dev dependency

### DIFF
--- a/django2pydantic/__init__.py
+++ b/django2pydantic/__init__.py
@@ -1,8 +1,12 @@
 """Super schema packages."""
 
+import django_stubs_ext
+
 from django2pydantic.registry import FieldTypeRegistry
 from django2pydantic.schema import BaseSchema
 from django2pydantic.types import Infer, InferExcept, ModelFields
+
+django_stubs_ext.monkeypatch()
 
 __all__ = ["BaseSchema", "FieldTypeRegistry", "Infer", "InferExcept", "ModelFields"]
 __version__ = "0.2.0"

--- a/django2pydantic/handlers/json.py
+++ b/django2pydantic/handlers/json.py
@@ -1,6 +1,6 @@
 """Handler for JSON fields."""
 
-from typing import Annotated, override, reveal_type
+from typing import override
 
 from django.db import models
 from pydantic import Json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["django>=5.1.3", "pydantic>=2.9.2"]
+dependencies = ["django>=5.1.3", "pydantic>=2.9.2", "django-stubs-ext>=5.1.1"]
 
 
 [project.urls]
@@ -70,7 +70,6 @@ dev = [
     "ruff>=0.7.3",
     "typeguard>=4.4.1",
     "wemake-python-styleguide>=1.0.0",
-    "django-stubs-ext>=5.1.1",
     "python-semantic-release>=9.14.0",
     "semgrep>=1.85.0",
     "project-config>=0.9.7",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,10 +1,5 @@
 """Django settings file for the tests."""
 
-import django_stubs_ext
-from django.db import models
-
-django_stubs_ext.monkeypatch(extra_classes=[models.BinaryField, models.JSONField])
-
 ALLOWED_HOSTS = ["*"]
 DEBUG_PROPAGATE_EXCEPTIONS = True
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = "==3.12.*"
 
 [[package]]
@@ -200,7 +201,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -457,6 +458,7 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
+    { name = "django-stubs-ext" },
     { name = "pydantic" },
 ]
 
@@ -467,7 +469,6 @@ dev = [
     { name = "debugpy" },
     { name = "django-ninja" },
     { name = "django-stubs", extra = ["compatible-mypy"] },
-    { name = "django-stubs-ext" },
     { name = "email-validator" },
     { name = "hypothesis" },
     { name = "import-linter" },
@@ -501,6 +502,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.1.3" },
+    { name = "django-stubs-ext", specifier = ">=5.1.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
 ]
 
@@ -511,7 +513,6 @@ dev = [
     { name = "debugpy", specifier = ">=1.8.8" },
     { name = "django-ninja", specifier = ">=1.3.0" },
     { name = "django-stubs", extras = ["compatible-mypy"], specifier = ">=5.1.1" },
-    { name = "django-stubs-ext", specifier = ">=5.1.1" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "hypothesis", specifier = ">=6.118.0" },
     { name = "import-linter", specifier = ">=2.1" },
@@ -848,7 +849,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },


### PR DESCRIPTION
Fixes #7

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NextGenContributions/django2pydantic/pull/16?shareId=c5e2cbda-8111-4007-a8b2-877467eec7b1).

## Summary by Sourcery

Build:
- Include `django-stubs-ext` as a dependency instead of a development dependency to ensure it is available in the production environment.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Include `django-stubs-ext` as a non-development dependency and remove redundant `django_stubs_ext` import and usage from the test settings.

### Why are these changes being made?
The `django-stubs-ext` package is needed for runtime type checking and must be available in production to ensure the code executes correctly, thus it was moved from development-only dependencies. Additionally, redundant imports and functionality in test settings were removed as they are no longer necessary, simplifying the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package initialization to improve compatibility with Django.

- **Chores**
	- Updated dependency configurations to include essential support libraries.
	- Removed unused code and streamlined internal logic.

- **Tests**
	- Simplified test configuration by eliminating redundant integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->