### PR TITLE
fix: Trunk's mypy environment missing deps

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   tests:
     uses: NextGenContributions/cicd-pipeline/.github/workflows/test.yml@main
+    permissions:
+      checks: write # For trunk to post annotations
+      contents: read # For repo checkout
     with:
       project_name: django2pydantic
     secrets:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,11 +10,16 @@ on:
       - "*"
 
 jobs:
-  tests:
-    uses: NextGenContributions/cicd-pipeline/.github/workflows/test.yml@main
+  trunk-check:
+    uses: NextGenContributions/cicd-pipeline/.github/workflows/trunk-check.yml@main
     permissions:
       checks: write # For trunk to post annotations
       contents: read # For repo checkout
+    secrets:
+      TRUNK_TOKEN: ${{ secrets.TRUNK_TOKEN }}
+
+  tests:
+    uses: NextGenContributions/cicd-pipeline/.github/workflows/test.yml@main
     with:
       project_name: django2pydantic
     secrets:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,7 +10,9 @@ runtimes:
   enabled:
     - go@1.21.0
     - node@18.20.5
-    - python@>=3.10.8
+  definitions:
+    - type: python
+      system_version: allowed
 lint:
   enabled:
     - actionlint@1.7.7
@@ -19,25 +21,20 @@ lint:
     - codespell@2.4.1
     - cspell@8.17.5
     - djlint@1.36.4
-    - flake8@7.1.2
+    - flake8
     - git-diff-check
     - gitleaks@8.24.0
     - hadolint@2.12.1-beta
     - markdown-link-check@3.13.6
     - markdown-table-prettify@3.6.0
     - markdownlint-cli2@0.17.2
-    - mypy@1.15.0:
-        packages:
-          # Required for mypy to correctly type-check Django and Pydantic code
-          - django-stubs@5.1.3
-          - pydantic@2.10.6
+    - mypy
     - osv-scanner@1.9.2
     - prettier@3.5.3
-    - pylint@3.3.4
-    - pyright@1.1.396
+    - pylint
+    - pyright
     - renovate@39.185.0
-    - ruff@0.9.9
-    - semgrep@1.110.0
+    - ruff
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - taplo@0.9.3

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -15,18 +15,31 @@ lint:
   enabled:
     - actionlint@1.7.7
     - bandit@1.8.3
+    - checkov@3.2.379
+    - codespell@2.4.1
+    - cspell@8.17.5
+    - djlint@1.36.4
+    - flake8@7.1.2
     - git-diff-check
-    - markdownlint@0.44.0
+    - gitleaks@8.24.0
+    - hadolint@2.12.1-beta
+    - markdown-link-check@3.13.6
+    - markdown-table-prettify@3.6.0
+    - markdownlint-cli2@0.17.2
     - mypy@1.15.0
     - osv-scanner@1.9.2
     - prettier@3.5.3
     - pylint@3.3.4
+    - pyright@1.1.396
     - renovate@39.185.0
     - ruff@0.9.9
+    - semgrep@1.110.0
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - taplo@0.9.3
+    - trivy@0.59.1
     - trufflehog@3.88.14
+    - vale@3.9.6
     - yamllint@1.35.1
   ignore:
     - linters:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,6 +28,7 @@ lint:
     - markdownlint-cli2@0.17.2
     - mypy@1.15.0:
         packages:
+          # Required for mypy to correctly type-check Django and Pydantic code
           - django-stubs@5.1.3
           - pydantic@2.10.6
     - osv-scanner@1.9.2

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -26,7 +26,10 @@ lint:
     - markdown-link-check@3.13.6
     - markdown-table-prettify@3.6.0
     - markdownlint-cli2@0.17.2
-    - mypy@1.15.0
+    - mypy@1.15.0:
+        packages:
+          - django-stubs@5.1.3
+          - pydantic@2.10.6
     - osv-scanner@1.9.2
     - prettier@3.5.3
     - pylint@3.3.4

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+[formats]
+markdoc = md
+
+[*.md]
+BasedOnStyles = Vale


### PR DESCRIPTION
Found hidden config settings to customize Trunk's plugin runtime environment 😄

## Summary by Sourcery

Enhancements:
- Add django-stubs and pydantic packages to the mypy environment in Trunk.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add missing dependencies `django-stubs@5.1.3` and `pydantic@2.10.6` to the Trunk's `mypy` environment in `.trunk/trunk.yaml`.

### Why are these changes being made?
The `mypy` environment was failing to properly type-check code requiring `django` and `pydantic` types, leading to potential type errors being overlooked. Adding these stubs ensures comprehensive type-checking for projects utilizing `django` and `pydantic`, improving overall code quality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced CI/CD pipeline with the addition of a new `trunk-check` job for improved integration.
  - Updated configuration for Python version specification and simplified lint tool versioning to use the latest available versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->