### PR TITLE
fix: Daily trunk check failure if the commit is already checked

### DIFF
--- a/.github/workflows/trunk-upgrade-and-check.yml
+++ b/.github/workflows/trunk-upgrade-and-check.yml
@@ -16,6 +16,7 @@ jobs:
     uses: NextGenContributions/cicd-pipeline/.github/workflows/trunk-check.yml@main
     with:
       check_mode: all
+      arguments: --replace # Overwrite previous check results for the same commit
     permissions:
       checks: write # For trunk to post annotations
       contents: read # For repo checkout


### PR DESCRIPTION


## Summary by Sourcery

CI:
- Adds the `--replace` argument to the trunk check workflow to overwrite previous check results for the same commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/36)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved our automated validation process to always use the most current results, ensuring more reliable commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add the `--replace` argument in the `trunk-check.yml` workflow to overwrite previous check results for the same commit.

### Why are these changes being made?
The daily trunk check failed when the commit was already checked, causing unnecessary interruptions in the CI/CD process. By adding the `--replace` argument, the workflow ensures that the checks can rerun on the same commit, improving stability and reliability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->