### PR TITLE
fix: Trunk permission to create/update label

### DIFF
--- a/.github/workflows/trunk-upgrade-and-check.yml
+++ b/.github/workflows/trunk-upgrade-and-check.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
   
   trunk-check:
     uses: NextGenContributions/cicd-pipeline/.github/workflows/trunk-check.yml@main


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add write permission to issues under `.github/workflows/trunk-upgrade-and-check.yml`.

### Why are these changes being made?

The changes are necessary to allow the workflow to create and update labels on issues, which is essential for automating issue management and ensuring proper labeling within the repository. Without this permission, the workflow may fail to execute these tasks, affecting development processes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->