### PR TITLE
cicd: Use dedicated GitHub App for auto release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,8 @@ jobs:
     uses: NextGenContributions/cicd-pipeline/.github/workflows/release.yml@main
     with:
       release_branch: main
+    secrets:
+      AUTO_RELEASE_PRIVATE_KEY : ${{ secrets.AUTO_RELEASE_PRIVATE_KEY }}
     needs: tests
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Updated release workflow to use a dedicated GitHub App authentication

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Integrate a dedicated GitHub App for automatic release by adding a new secret `AUTO_RELEASE_PRIVATE_KEY` to the CI/CD workflow configuration.

### Why are these changes being made?
To enhance security and streamline the release process by utilizing a dedicated GitHub App, ensuring that sensitive credentials are managed through GitHub Secrets and minimizing manual intervention. This approach allows automated releases while maintaining best security practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->