### PR TITLE
chore: Fix relation title and description

### DIFF
--- a/django2pydantic/base.py
+++ b/django2pydantic/base.py
@@ -374,8 +374,16 @@ def _determine_field_type(
         )
         raise TypeError(msg)
 
-    title = force_str(getattr(django_field, "verbose_name", None))
-    description = force_str(getattr(django_field, "help_text", None))
+    target_field = django_field
+    if dj_field_type in {ManyToOneRel, OneToOneRel, ManyToManyRel}:
+        target_field = django_field.remote_field  # type: ignore[union-attr,assignment]
+
+    title = None
+    description = None
+    if verbose_name := getattr(target_field, "verbose_name", None):
+        title = force_str(verbose_name)
+    if help_text := getattr(target_field, "help_text", None):
+        description = force_str(help_text)
 
     return (
         field_type,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the relationship field title and description retrieval to support relation types in `django2pydantic/base.py`.

### Why are these changes being made?

These changes address a limitation where the title and description values were not properly retrieved for Django relational fields (`ManyToOneRel`, `OneToOneRel`, `ManyToManyRel`). By handling these fields individually and using `remote_field`, the code ensures accurate metadata extraction, improving compatibility with relational fields in Django models.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/82)
<!-- Reviewable:end -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the handling of field metadata in the Django to Pydantic conversion process, refining the extraction of titles and descriptions from Django fields, especially for relational fields, thereby improving the clarity and usability of the generated Pydantic models.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved extraction of field titles and descriptions for relational fields, ensuring more accurate display of metadata in user-facing forms and interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->