### PR TITLE
Fix reverse relation title and description

### DIFF
--- a/django2pydantic/base.py
+++ b/django2pydantic/base.py
@@ -375,9 +375,6 @@ def _determine_field_type(
         raise TypeError(msg)
 
     target_field = django_field
-    if dj_field_type in {ManyToOneRel, OneToOneRel, ManyToManyRel}:
-        target_field = django_field.remote_field  # type: ignore[union-attr,assignment]
-
     title = None
     description = None
     if verbose_name := getattr(target_field, "verbose_name", None):

--- a/django2pydantic/handlers/base.py
+++ b/django2pydantic/handlers/base.py
@@ -10,7 +10,7 @@ from typing import (
     Generic,
     Protocol,
     TypeVar,
-    Union,
+    Union,  # pyright: ignore [reportDeprecated]
     cast,
     override,
     runtime_checkable,
@@ -26,7 +26,6 @@ from django.core.validators import (
     StepValueValidator,
 )
 from django.db import models
-from django.db.models import ForeignObjectRel
 from django.utils.encoding import force_str
 from pydantic import Field
 from pydantic.fields import FieldInfo
@@ -248,12 +247,13 @@ class DjangoFieldHandler(  # noqa: WPS214
     def __init__(self, field_obj: TDjangoField_co) -> None:  # pyright: ignore[reportMissingSuperCall]
         """Initialize the field handler."""
         self.field_obj: models.Field[SetType, GetType] | ForwardRel
-        if isinstance(field_obj, ForeignObjectRel):
+        if isinstance(field_obj, models.ForeignObjectRel):
             if field_obj.related_model == "self":
                 related_model = field_obj.model
             else:
                 related_model = field_obj.related_model
             self.field_obj = related_model._meta.pk  # noqa: SLF001  # pyright: ignore [reportUnknownMemberType]
+            self.related_model: type[models.Model] | None = related_model
         else:
             self.field_obj = field_obj
 
@@ -421,5 +421,5 @@ class DjangoFieldHandler(  # noqa: WPS214
             )
 
         if self.field_obj.null:
-            return Union[self.get_pydantic_type_raw(), None]  # type: ignore[return-value]
+            return Union[self.get_pydantic_type_raw(), None]  # type: ignore[return-value]  # noqa: UP007
         return self.get_pydantic_type_raw()

--- a/django2pydantic/handlers/relational.py
+++ b/django2pydantic/handlers/relational.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Generic, TypeVar, Union, override
 
 from django.db import models
 from django.db.models.fields.related import RelatedField
+from django.utils.encoding import force_str
 from pydantic_core import PydanticUndefined
 
 from django2pydantic.handlers.base import DjangoFieldHandler, PydanticConverter
@@ -74,7 +75,7 @@ class RelatedFieldHandler(
         # relationship at the database level.
         # Ref: https://docs.djangoproject.com/en/5.1/ref/models/fields/#manytomanyfield
         if not self.field_obj.many_to_many and self.field_obj.null:
-            return Union[pydantic_type, None]  # type: ignore[return-value]
+            return Union[pydantic_type, None]  # type: ignore[return-value]  # noqa: UP007
         return pydantic_type
 
     def _get_field_type_handler(
@@ -209,6 +210,13 @@ class ManyToManyRelHandler(ReverseRelatedFieldHandler[models.ManyToManyRel]):
     def field(cls) -> type[models.ManyToManyRel]:
         return models.ManyToManyRel
 
+    @property
+    @override
+    def title(self) -> str | None:
+        if vn := self.related_model._meta.verbose_name_plural:  # noqa: SLF001 # pyright: ignore [reportOptionalMemberAccess]
+            return force_str(vn)
+        return super().title
+
     @override
     def get_pydantic_type(
         self,
@@ -228,6 +236,13 @@ class OneToOneRelHandler(ReverseRelatedFieldHandler[models.OneToOneRel]):
     def field(cls) -> type[models.OneToOneRel]:
         return models.OneToOneRel
 
+    @property
+    @override
+    def title(self) -> str | None:
+        if vn := self.related_model._meta.verbose_name:  # noqa: SLF001  # pyright: ignore [reportOptionalMemberAccess]
+            return force_str(vn)
+        return super().title
+
     @override
     def get_pydantic_type(
         self,
@@ -242,6 +257,13 @@ class ManyToOneRelHandler(ReverseRelatedFieldHandler[models.ManyToOneRel]):
     @override
     def field(cls) -> type[models.ManyToOneRel]:
         return models.ManyToOneRel
+
+    @property
+    @override
+    def title(self) -> str | None:
+        if vn := self.related_model._meta.verbose_name_plural:  # noqa: SLF001  # pyright: ignore [reportOptionalMemberAccess]
+            return force_str(vn)
+        return super().title
 
     @override
     def get_pydantic_type(

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -127,7 +127,6 @@ def is_correct_field_type_and_format(
     return datas[field]["type"] == type_ and datas[field]["format"] == format
 
 
-@pytest.mark.skip(reason="WIP")
 @pytest.mark.parametrize("field", DjangoFieldTypes)
 @given(
     help_text=st.text(alphabet=printable).filter(
@@ -160,7 +159,6 @@ def test_field_type_and_format_is_correct_openapi_equivalent(field: FieldClass) 
     )
 
 
-@pytest.mark.skip(reason="WIP")
 @pytest.mark.parametrize("field", DjangoFieldTypes)
 @given(
     help_text=st.text(alphabet=printable).filter(

--- a/tests/test_related_field_title_description.py
+++ b/tests/test_related_field_title_description.py
@@ -1,6 +1,6 @@
 """Test cases for Django models to Pydantic models conversion."""
 
-from typing import Any
+from typing import Any, final
 
 from django.db import models
 
@@ -21,6 +21,7 @@ def test_related_field_description_is_set_from_help_text() -> None:
     """Test that the field description is set from the help text if it exists."""
     help_text = "This is a test help text for the field."
 
+    @final
     class TestModel(models.Model):
         field = models.ForeignKey(
             help_text=help_text,
@@ -29,11 +30,10 @@ def test_related_field_description_is_set_from_help_text() -> None:
             related_name="related_field",
         )
 
-        class Meta:
-            app_label = "test_app"
-
-    class FieldSchema(BaseSchema):
-        config = SchemaConfig(model=TestModel, fields={"id": Infer, "field": Infer})
+    class FieldSchema(BaseSchema[TestModel]):
+        config: SchemaConfig[TestModel] = SchemaConfig(
+            model=TestModel, fields={"id": Infer, "field": Infer}
+        )
 
     openapi_schema = FieldSchema.model_json_schema()
     assert (
@@ -46,6 +46,7 @@ def test_related_field_title_is_set_from_verbose_name() -> None:
     """Test that the field title is set from the verbose name if it exists."""
     title = "This is a test title for the field."
 
+    @final
     class TestModel(models.Model):
         field = models.ForeignKey(
             verbose_name=title,
@@ -54,11 +55,99 @@ def test_related_field_title_is_set_from_verbose_name() -> None:
             related_name="related_field",
         )
 
-        class Meta:
-            app_label = "test_app"
-
-    class FieldSchema(BaseSchema):
-        config = SchemaConfig(model=TestModel, fields={"id": Infer, "field": Infer})
+    class FieldSchema(BaseSchema[TestModel]):
+        config: SchemaConfig[TestModel] = SchemaConfig[TestModel](
+            model=TestModel, fields={"id": Infer, "field": Infer}
+        )
 
     openapi_schema = FieldSchema.model_json_schema()
     assert openapi_schema["properties"]["field"]["title"].strip() == title.strip()
+
+
+def test_OneToOneField_reverse_relationship_title_is_set_from_verbose_name() -> None:
+    """Test that the reverse relation field title is set from the verbose name."""
+    title = "This is a test title for the reverse relationship field."
+    related_name = "b_set"
+
+    @final
+    class A(models.Model):
+        pass
+
+    @final
+    class B(models.Model):  # pyright: ignore[reportUnusedClass]
+        a = models.OneToOneField(
+            A,
+            on_delete=models.CASCADE,
+            related_name=related_name,
+        )
+
+        @final
+        class Meta:
+            verbose_name = title
+
+    class FieldSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: Infer}
+        )
+
+    openapi_schema = FieldSchema.model_json_schema()
+    assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()
+
+
+def test_ManyToManyField_reverse_relationship_title_is_set_from_verbose_name() -> None:
+    """Test that the reverse relation field title is set from the verbose name."""
+    title = "This is a test title for the reverse relationship field."
+    related_name = "b_set"
+
+    @final
+    class A(models.Model):
+        pass
+
+    @final
+    class B(models.Model):  # pyright: ignore[reportUnusedClass]
+        a = models.ManyToManyField(
+            A,
+            related_name=related_name,
+        )
+
+        @final
+        class Meta:
+            verbose_name_plural = title
+
+    class FieldSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: Infer}
+        )
+
+    openapi_schema = FieldSchema.model_json_schema()
+    assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()
+
+
+def test_ForeignKey_reverse_relationship_title_is_set_from_verbose_name() -> None:
+    """Test that the reverse relation field title is set from the verbose name."""
+    title = "This is a test title for the reverse relationship field."
+    related_name = "b_set"
+
+    @final
+    class A(models.Model):
+        pass
+
+    @final
+    class B(models.Model):  # pyright: ignore[reportUnusedClass]
+        a = models.ForeignKey(
+            A,
+            related_name=related_name,
+            on_delete=models.CASCADE,
+        )
+
+        @final
+        class Meta:
+            verbose_name_plural = title
+
+    class FieldSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: Infer}
+        )
+
+    openapi_schema = FieldSchema.model_json_schema()
+    assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()


### PR DESCRIPTION
## Summary by Sourcery

Fix reverse relationship field titles to use Django model verbose names and update tests accordingly

Enhancements:
- Use verbose_name and verbose_name_plural from related models as titles for reverse relationships in schema handlers
- Set field descriptions from help_text on related fields

Tests:
- Add tests for OneToOne, ManyToMany, and ForeignKey reverse relationship title resolution
- Refactor existing tests to use generic BaseSchema typing and remove deprecated app_label metadata

Chores:
- Add lint and type ignore directives (noqa, pyright) and clean up deprecated union imports
- Remove legacy field type determination logic for relational fields 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the handling of reverse relations in Django models converted to Pydantic models, improving the retrieval of titles and descriptions for related fields. It also updates the testing suite with new test cases for verifying reverse relationship field titles, ensuring better integration with Pydantic's schema generation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are well-defined and the addition of tests makes it straightforward to verify functionality.
-->
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/85)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display of reverse relationship field titles in schemas, using the related model’s verbose name or plural name where available.

- **Bug Fixes**
  - Enabled previously skipped tests to ensure field descriptions and OpenAPI type/format correctness.

- **Tests**
  - Introduced new tests to verify that reverse relationship field titles are set from related model verbose names.
  - Improved type safety and metadata usage in test models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->