### PR TITLE
fix: reverse relation titles more complete

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -46,6 +46,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "S101",  # Checks for uses of the assert keyword
     "DJ008", # Checks that a __str__ method is defined in Django models
     "D100",  # Missing docstring in public module
+    "N802",  # Allow uppercase function names for tests
 ]
 
 [lint.pydocstyle]

--- a/django2pydantic/handlers/base.py
+++ b/django2pydantic/handlers/base.py
@@ -86,13 +86,33 @@ class PydanticConverter(Protocol[TFieldType_co]):
         """
         raise NotImplementedError
 
+    @property
+    def title(self) -> str | None:
+        """Return the title of the field.
+
+        Returns:
+            str | None: The title of the field.
+
+        """
+        raise NotImplementedError
+
+    @property
+    def description(self) -> str | None:
+        """Return the description of the field.
+
+        Returns:
+            str | None: The description of the field.
+
+        """
+        raise NotImplementedError
+
 
 class FieldTypeHandler(Generic[TFieldType_co], PydanticConverter[TFieldType_co], ABC):  # noqa: WPS214 - Found too many methods
     """Abstract base class for handling generic model fields."""
 
     @override
-    def __init__(self, field_obj: TFieldType_co) -> None:
-        pass
+    def __init__(self, field_obj: TFieldType_co) -> None:  # pyright: ignore[reportMissingSuperCall]
+        pass  # noqa: WPS420
 
     @classmethod
     @abstractmethod
@@ -101,6 +121,7 @@ class FieldTypeHandler(Generic[TFieldType_co], PydanticConverter[TFieldType_co],
         """Return the type of the field."""
 
     @property
+    @override
     def description(self) -> str | None:
         """Return the description of the field."""
         return None
@@ -116,6 +137,7 @@ class FieldTypeHandler(Generic[TFieldType_co], PydanticConverter[TFieldType_co],
         return PydanticUndefined
 
     @property
+    @override
     def title(self) -> str | None:
         """Return the title of the field."""
         return None

--- a/tests/test_related_field_title_description.py
+++ b/tests/test_related_field_title_description.py
@@ -71,7 +71,7 @@ def test_OneToOneField_reverse_relationship_title_is_set_from_verbose_name() -> 
 
     @final
     class A(models.Model):
-        pass
+        """Test model."""
 
     @final
     class B(models.Model):  # pyright: ignore[reportUnusedClass]
@@ -90,18 +90,31 @@ def test_OneToOneField_reverse_relationship_title_is_set_from_verbose_name() -> 
             model=A, fields={"id": Infer, related_name: Infer}
         )
 
+    class DictSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: {"id": Infer}}
+        )
+
     openapi_schema = FieldSchema.model_json_schema()
     assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()
 
+    openapi_schema_dict = DictSchema.model_json_schema()
+    assert (
+        openapi_schema_dict["properties"][related_name]["title"].strip()
+        == title.strip()
+    )
 
-def test_ManyToManyField_reverse_relationship_title_is_set_from_verbose_name() -> None:
+
+def test_ManyToManyField_reverse_relationship_title_is_set_from_verbose_name_plural() -> (
+    None
+):
     """Test that the reverse relation field title is set from the verbose name."""
     title = "This is a test title for the reverse relationship field."
     related_name = "b_set"
 
     @final
     class A(models.Model):
-        pass
+        """Test model."""
 
     @final
     class B(models.Model):  # pyright: ignore[reportUnusedClass]
@@ -119,18 +132,31 @@ def test_ManyToManyField_reverse_relationship_title_is_set_from_verbose_name() -
             model=A, fields={"id": Infer, related_name: Infer}
         )
 
+    class DictSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: {"id": Infer}}
+        )
+
     openapi_schema = FieldSchema.model_json_schema()
     assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()
 
+    openapi_schema_dict = DictSchema.model_json_schema()
+    assert (
+        openapi_schema_dict["properties"][related_name]["title"].strip()
+        == title.strip()
+    )
 
-def test_ForeignKey_reverse_relationship_title_is_set_from_verbose_name() -> None:
+
+def test_ForeignKey_reverse_relationship_title_is_set_from_verbose_name_plural() -> (
+    None
+):
     """Test that the reverse relation field title is set from the verbose name."""
     title = "This is a test title for the reverse relationship field."
     related_name = "b_set"
 
     @final
     class A(models.Model):
-        pass
+        """Test model."""
 
     @final
     class B(models.Model):  # pyright: ignore[reportUnusedClass]
@@ -149,5 +175,16 @@ def test_ForeignKey_reverse_relationship_title_is_set_from_verbose_name() -> Non
             model=A, fields={"id": Infer, related_name: Infer}
         )
 
+    class DictSchema(BaseSchema[A]):
+        config: SchemaConfig[A] = SchemaConfig(
+            model=A, fields={"id": Infer, related_name: {"id": Infer}}
+        )
+
     openapi_schema = FieldSchema.model_json_schema()
     assert openapi_schema["properties"][related_name]["title"].strip() == title.strip()
+
+    openapi_schema_dict = DictSchema.model_json_schema()
+    assert (
+        openapi_schema_dict["properties"][related_name]["title"].strip()
+        == title.strip()
+    )


### PR DESCRIPTION
+ improved error messages for missing fields
+ some lint issue fixes

## Summary by Sourcery

Use field type handlers to source title and description metadata and simplify related field resolution, improve missing-field error messages, extend reverse relationship title tests, and adjust lint rules.

Bug Fixes:
- Improve error message for undefined Django fields by listing available field names.

Enhancements:
- Add abstract `title` and `description` properties to field handlers and use them in `_determine_field_type`.
- Pass `field_type_registry` into related field resolution to enable handler-based metadata extraction.

Tests:
- Extend reverse relationship title tests with nested dict schema configurations for OneToOne, ManyToMany, and ForeignKey relations.
- Rename tests for plural naming and add docstrings to test models.

Chores:
- Allow uppercase function names in tests via `.ruff.toml` update. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request improves the handling of reverse relation titles in Django models by enhancing error messages and introducing a field type registry. It also adds properties for field titles and descriptions, along with a new DictSchema class for schema handling. Linting rules have been updated, and new tests ensure the functionality of these enhancements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/87)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for setting field titles and descriptions in generated schemas, using values provided by field handlers.
- **Bug Fixes**
  - Enhanced error messages when a requested field is not found in a Django model, now listing available field names.
- **Tests**
  - Expanded test coverage for reverse relationship field titles, including additional schema configurations and plural naming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Enhance support for reverse relationship field titles by retrieving both singular and plural verbose names and updating the test cases to reflect the advanced handling of these titles.

### Why are these changes being made?
To address an issue where reverse relationship fields did not have a complete and informative title derived from Django's verbose_name attributes, which could lead to unclear or missing information in the generated Pydantic model schema. By utilizing the `field_type_registry` to determine the field title and description, the code now provides a robust mechanism for handling various field types and improves the clarity of schema definitions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->