### PR TITLE
chore: No description for reverse relations

### DIFF
--- a/django2pydantic/handlers/relational.py
+++ b/django2pydantic/handlers/relational.py
@@ -194,6 +194,12 @@ class ReverseRelatedFieldHandler(
     def default(self) -> None:
         return None  # So that the field is not marked as required
 
+    @property
+    @override
+    def description(self) -> None:
+        # TODO(jhassine): https://github.com/NextGenContributions/django2pydantic/issues/88
+        return None
+
     @override
     def get_pydantic_type_raw(
         self,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `description` property to `ReverseRelatedFieldHandler` class returning `None` with a TODO comment linking to a GitHub issue for future enhancement.

### Why are these changes being made?

To ensure consistency in handling reverse relations by providing a placeholder for the `description` property while planning to address the details in the linked issue. This temporary solution streamlines current functionality without marking fields as required and aligns with broader project objectives.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/89)
<!-- Reviewable:end -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the ReverseRelatedFieldHandler by adding a description property override that consistently returns None, improving the handling of reverse relations in the Django to Pydantic conversion process as part of ongoing maintenance.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>