### PR TITLE
fix: JSONField validation should accept python object

### DIFF
--- a/django2pydantic/handlers/json.py
+++ b/django2pydantic/handlers/json.py
@@ -1,15 +1,28 @@
 """Handler for JSON fields."""
 
-from typing import override
+import json
+from types import UnionType
+from typing import Annotated, Any, override
 
 from django.db import models
-from pydantic import Json
+from pydantic import BeforeValidator, Json
 
 from django2pydantic.handlers.base import DjangoFieldHandler
-from django2pydantic.types import GetType, SetType
+from django2pydantic.types import GetType, SetType, SupportedPydanticTypes
 
 
-class JSONFieldHandler(DjangoFieldHandler[models.JSONField[SetType, GetType]]):
+def ensure_json_str(value: Any) -> str:  # pyright: ignore [reportExplicitAny]
+    """Ensure the value being validated is a string.
+
+    Pydantic's Json type expects a string representation of JSON, passing in a python
+    object will raise validation error. This function ensures the value is a string.
+    """
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+class JSONFieldHandler(DjangoFieldHandler[models.JSONField[SetType, GetType]]):  # pyright: ignore [reportExplicitAny]
     """Handler for JSON fields."""
 
     @classmethod
@@ -20,5 +33,13 @@ class JSONFieldHandler(DjangoFieldHandler[models.JSONField[SetType, GetType]]):
     @override
     def get_pydantic_type_raw(
         self,
-    ):
-        return Json
+    ) -> UnionType | SupportedPydanticTypes | list[SupportedPydanticTypes]:
+        return Json  # type: ignore[no-any-return]
+
+    @override
+    def get_pydantic_type(
+        self,
+    ) -> UnionType | SupportedPydanticTypes | list[SupportedPydanticTypes]:
+        return Annotated[  # type: ignore[return-value]
+            super().get_pydantic_type(), BeforeValidator(ensure_json_str)
+        ]

--- a/tests/test_jsonfield.py
+++ b/tests/test_jsonfield.py
@@ -1,0 +1,26 @@
+from django.db import models
+
+from django2pydantic import BaseSchema, Infer
+from django2pydantic.schema import SchemaConfig
+
+
+def test_schema_with_jsonfield_should_accept_python_object() -> None:
+    """Python object should not raise validation error."""
+
+    class ModelA(models.Model):
+        config = models.JSONField(default=dict)
+
+    class SchemaA(BaseSchema[ModelA]):  # pylint: disable=too-few-public-methods
+        config = SchemaConfig[ModelA](
+            model=ModelA,
+            fields={
+                "config": Infer,
+            },
+        )
+
+    _ = SchemaA(config={"name": "test"})
+    _ = SchemaA(config=["test", 1, 2.0, True, None])
+    _ = SchemaA(config="123")
+    _ = SchemaA(config=123)
+    _ = SchemaA(config=123.0)
+    _ = SchemaA(config=True)


### PR DESCRIPTION


## Summary by Sourcery

Enable Django JSONField schemas to accept and automatically serialize Python objects by injecting a pre-validation step and adding corresponding tests.

Bug Fixes:
- Allow JSONField validation to accept native Python objects instead of only JSON strings

Enhancements:
- Add ensure_json_str helper and apply it via a Pydantic BeforeValidator on JSON fields

Tests:
- Add tests to verify JSONField accepts dicts, lists, primitives, and strings without validation errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/93)
<!-- Reviewable:end -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in JSONField validation, enabling it to accept Python objects alongside strings. A new validator has been introduced to convert these objects to JSON strings for Pydantic, and tests have been added to verify the handling of various Python types.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved support for JSON fields, allowing Pydantic schemas to accept various Python object types (such as dictionaries, lists, and primitives) for JSON fields without validation errors.
- **Tests**
	- Added tests to confirm that JSON fields in schemas accept multiple Python object types as valid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor JSONFieldHandler to validate JSONField inputs by accepting Python objects and converting them to JSON strings before passing them to Pydantic's Json type, and add corresponding tests for this functionality.

### Why are these changes being made?

This change ensures compatibility of Django JSON fields with Pydantic by addressing the validation error that occurs when Python objects are passed directly into Json type, thus enhancing usability by automatically handling JSON serialization. The approach includes a new utility function, `ensure_json_str`, to handle serialization, evidenced by the expanded test suite verifying the new acceptance criteria.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->