### PR TITLE
fix: Test runs with nox should respect uv.lock deps

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,17 @@ nox.options.default_venv_backend = "uv"
 @nox.parametrize("django_version", ["4.2", "5.0", "5.1", "5.2"])
 def tests(session: nox.Session, django_version: str) -> None:
     """Run the test suite."""
-    session.install(".", f"django=={django_version}", "--group", "tests")
+    # https://nox.thea.codes/en/stable/cookbook.html#using-a-lockfile
+    _ = session.run_install(
+        "uv",
+        "sync",
+        "--no-dev",
+        "--group=tests",
+        f"--python={session.virtualenv.location}",
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+    # Override django version from lockfile
+    session.install(f"django=={django_version}")
 
     # a fix so .ipynb tests imports succeed:
     session.env["PYTHONPATH"] = str(Path(__file__).parent.resolve())


### PR DESCRIPTION
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Make nox test sessions use uv.lock for dependency management and explicitly install the specified Django version

Build:
- Use `uv sync` in the noxfile to install locked dependencies for the tests
- Install the requested Django version separately after syncing dependencies

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/django2pydantic/214)
<!-- Reviewable:end -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the nox test sessions by ensuring they respect the dependencies in the uv.lock file. It introduces 'uv sync' for effective dependency management and installs the specified Django version separately after syncing, improving test environment reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability and consistency of test environments using lockfile-backed dependency installs.
  * Ensures the intended Django version is applied during test runs across matrices.
  * Maintains compatibility for notebook-related tests.

* **Chores**
  * Standardized dependency installation workflow for repeatable, faster setups.
  * Streamlined environment handling for test execution.

* **Documentation**
  * Added a reference link to guidance on lockfile-based installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->